### PR TITLE
Add support for twigcs 4.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Accessibility rules for TwigCS",
     "type": "library",
     "require": {
-        "friendsoftwig/twigcs": "^3.2"
+        "friendsoftwig/twigcs": "^4.0"
     },
     "license": "MIT",
     "authors": [

--- a/src/Rules/AriaRoles.php
+++ b/src/Rules/AriaRoles.php
@@ -2,10 +2,10 @@
 
 namespace NdB\TwigCSA11Y\Rules;
 
-use Allocine\Twigcs\Rule\AbstractRule;
-use Allocine\Twigcs\Rule\RuleInterface;
+use FriendsOfTwig\Twigcs\Rule\AbstractRule;
+use FriendsOfTwig\Twigcs\Rule\RuleInterface;
+use FriendsOfTwig\Twigcs\TwigPort\TokenStream;
 use Twig\Token as TwigToken;
-use Twig\TokenStream;
 
 class AriaRoles extends AbstractRule implements RuleInterface
 {
@@ -29,7 +29,7 @@ class AriaRoles extends AbstractRule implements RuleInterface
     ];
 
     /**
-     * @var \Allocine\Twigcs\Validator\Violation[]
+     * @var \FriendsOfTwig\Twigcs\Validator\Violation[]
      */
     protected $violations = [];
 

--- a/src/Rules/BannedHTMLTags.php
+++ b/src/Rules/BannedHTMLTags.php
@@ -2,10 +2,10 @@
 
 namespace NdB\TwigCSA11Y\Rules;
 
-use Allocine\Twigcs\Rule\AbstractRule;
-use Allocine\Twigcs\Rule\RuleInterface;
+use FriendsOfTwig\Twigcs\Rule\AbstractRule;
+use FriendsOfTwig\Twigcs\Rule\RuleInterface;
+use FriendsOfTwig\Twigcs\TwigPort\TokenStream;
 use Twig\Token as TwigToken;
-use Twig\TokenStream;
 
 class BannedHTMLTags extends AbstractRule implements RuleInterface
 {
@@ -15,7 +15,7 @@ class BannedHTMLTags extends AbstractRule implements RuleInterface
     ];
 
     /**
-     * @var \Allocine\Twigcs\Validator\Violation[]
+     * @var \FriendsOfTwig\Twigcs\Validator\Violation[]
      */
     protected $violations = [];
 

--- a/src/Rules/TabIndex.php
+++ b/src/Rules/TabIndex.php
@@ -2,15 +2,15 @@
 
 namespace NdB\TwigCSA11Y\Rules;
 
-use Allocine\Twigcs\Rule\AbstractRule;
-use Allocine\Twigcs\Rule\RuleInterface;
+use FriendsOfTwig\Twigcs\Rule\AbstractRule;
+use FriendsOfTwig\Twigcs\Rule\RuleInterface;
+use FriendsOfTwig\Twigcs\TwigPort\TokenStream;
 use Twig\Token as TwigToken;
-use Twig\TokenStream;
 
 class TabIndex extends AbstractRule implements RuleInterface
 {
     /**
-     * @var \Allocine\Twigcs\Validator\Violation[]
+     * @var \FriendsOfTwig\Twigcs\Validator\Violation[]
      */
     protected $violations = [];
 

--- a/src/Ruleset.php
+++ b/src/Ruleset.php
@@ -2,14 +2,19 @@
 
 namespace NdB\TwigCSA11Y;
 
-use Allocine\Twigcs\Ruleset\RulesetInterface;
-use Allocine\Twigcs\Validator\Violation;
+use FriendsOfTwig\Twigcs\Ruleset\RulesetInterface;
+use FriendsOfTwig\Twigcs\Validator\Violation;
 use NdB\TwigCSA11Y\Rules\AriaRoles;
 use NdB\TwigCSA11Y\Rules\BannedHTMLTags;
 use NdB\TwigCSA11Y\Rules\TabIndex;
 
 class Ruleset implements RulesetInterface
 {
+    public function __construct(int $twigMajorVersion)
+    {
+
+    }
+
     public function getRules()
     {
         return [


### PR DESCRIPTION
Thank you for this plugin.

Atm we can't use this for version 4.x of friendsoftwig/twigcs.

```
$ composer require --dev nielsdeblaauw/twigcs-a11y
Using version ^0.1.1 for nielsdeblaauw/twigcs-a11y
./composer.json has been updated
Running composer update nielsdeblaauw/twigcs-a11y
Loading composer repositories with package information
Updating dependencies
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires nielsdeblaauw/twigcs-a11y ^0.1.1 -> satisfiable by nielsdeblaauw/twigcs-a11y[0.1.1].
    - nielsdeblaauw/twigcs-a11y 0.1.1 requires friendsoftwig/twigcs ^3.2 -> found friendsoftwig/twigcs[v3.2.0, v3.2.1, v3.2.2, 3.2.x-dev] but it conflicts with your root composer.json require (^4.0).

Use the option --with-all-dependencies (-W) to allow upgrades, downgrades and removals for packages currently locked to specific versions.

Installation failed, reverting ./composer.json and ./composer.lock to their original content.

```